### PR TITLE
New param hwRemoved:uint in API V2.13

### DIFF
--- a/lib/sdrplay/sdrplay_source_c.cc
+++ b/lib/sdrplay/sdrplay_source_c.cc
@@ -205,7 +205,7 @@ int sdrplay_source_c::work(int noutput_items,
 void sdrplay_source_c::streamCallback(short *xi, short *xq,
                                       unsigned int firstSampleNum,
                                       int grChanged, int rfChanged, int fsChanged,
-                                      unsigned int numSamples, unsigned int reset)
+                                      unsigned int numSamples, unsigned int reset, unsigned int hwRemoved)
 {
   unsigned int i = 0;
   _reinit = false;
@@ -243,17 +243,15 @@ void sdrplay_source_c::streamCallback(short *xi, short *xq,
 }
 
 // Callback wrapper
-void sdrplay_source_c::streamCallbackWrap(short *xi, short *xq,
-                                          unsigned int firstSampleNum,
-                                          int grChanged, int rfChanged, int fsChanged,
-                                          unsigned int numSamples, unsigned int reset,
-                                          void *cbContext)
+void sdrplay_source_c::streamCallbackWrap(short *xi, short *xq, unsigned int firstSampleNum, int grChanged, int rfChanged,
+                               int fsChanged, unsigned int numSamples, unsigned int reset, unsigned int hwRemoved,
+                               void *cbContext)
 {
   sdrplay_source_c *obj = (sdrplay_source_c *)cbContext;
   obj->streamCallback(xi, xq,
                       firstSampleNum,
                       grChanged, rfChanged, fsChanged,
-                      numSamples, reset);
+                      numSamples, reset, hwRemoved);
 }
 
 // Called by strplay streamer thread when gain reduction is changed.

--- a/lib/sdrplay/sdrplay_source_c.h
+++ b/lib/sdrplay/sdrplay_source_c.h
@@ -134,13 +134,12 @@ private:
   int checkLNA(int lna);
   void streamCallback(short *xi, short *xq, unsigned int firstSampleNum,
                       int grChanged, int rfChanged, int fsChanged,
-                      unsigned int numSamples, unsigned int reset);
+                      unsigned int numSamples, unsigned int reset, unsigned int hwRemoved);
   void gainChangeCallback(unsigned int gRdB, unsigned int lnaGRdB);
 
-  static void streamCallbackWrap(short *xi, short *xq, unsigned int firstSampleNum,
-                                 int grChanged, int rfChanged, int fsChanged,
-                                 unsigned int numSamples, unsigned int reset,
-                                 void *cbContext);
+  static void streamCallbackWrap(short *xi, short *xq, unsigned int firstSampleNum, int grChanged, int rfChanged,
+                               int fsChanged, unsigned int numSamples, unsigned int reset, unsigned int hwRemoved, void *cbContext);
+
   static void gainChangeCallbackWrap(unsigned int gRdB, unsigned int lnaGRdB, void *cbContext);
 
    bool _auto_gain;


### PR DESCRIPTION
Did not build with API V 2.13.... adjusted streamCallback.